### PR TITLE
fix name bug

### DIFF
--- a/accountmanager/accountmanager.go
+++ b/accountmanager/accountmanager.go
@@ -479,7 +479,7 @@ func (am *AccountManager) GetAccountFromValue(accountName common.Name, key strin
 	if err := rlp.DecodeBytes(value, &acct); err != nil {
 		return nil, ErrAccountNotExist
 	}
-	if !common.IsSameName(acct.AcctName, accountName) {
+	if acct.AcctName != accountName {
 		return nil, ErrAccountNameInvalid
 	}
 	return &acct, nil
@@ -509,7 +509,7 @@ func (am *AccountManager) TransferAsset(fromAccount common.Name, toAccount commo
 	if value.Cmp(big.NewInt(0)) < 0 {
 		return ErrAmountValueInvalid
 	}
-	if common.IsSameName(fromAccount, toAccount) {
+	if fromAccount == toAccount {
 		return nil
 	}
 	val, err := fromAcct.GetBalanceByID(assetID)

--- a/common/name.go
+++ b/common/name.go
@@ -31,13 +31,7 @@ func IsValidName(s string) bool {
 	return regexp.MustCompile("^[a-z0-9]{8,16}$").MatchString(s)
 }
 
-func IsSameName(srcName Name, destName Name) bool {
-	if srcName == destName {
-		return true
-	}
-	return false
-}
-
+// StrToName  returns Name with string of s.
 func StrToName(s string) Name {
 	n, err := parseName(s)
 	if err != nil {
@@ -54,10 +48,12 @@ func parseName(s string) (Name, error) {
 	return n, nil
 }
 
+// BytesToName returns Name with value b.
 func BytesToName(b []byte) (Name, error) {
 	return parseName(string(b))
 }
 
+// BigToName returns Name with byte values of b.
 func BigToName(b *big.Int) (Name, error) { return BytesToName(b.Bytes()) }
 
 // SetString  sets the name to the value of b..
@@ -80,11 +76,13 @@ func (n *Name) UnmarshalJSON(data []byte) error {
 	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
 		input = input[1 : len(input)-1]
 	}
-	dec, err := parseName(string(input))
-	if err != nil {
-		return err
+	if len(input) > 0 {
+		dec, err := parseName(string(input))
+		if err != nil {
+			return err
+		}
+		*n = dec
 	}
-	*n = dec
 	return nil
 }
 
@@ -93,4 +91,5 @@ func (n Name) String() string {
 	return string(n)
 }
 
+// Big converts a name to a big integer.
 func (n Name) Big() *big.Int { return new(big.Int).SetBytes([]byte(n.String())) }


### PR DESCRIPTION
if name is nil, " invalid name" error will happen when unmarshall Name struct.